### PR TITLE
Adicionar teste de API com método GET para buscar um usuário cadastrado através do id #12

### DIFF
--- a/ApiTesting/api_testing_users.robot
+++ b/ApiTesting/api_testing_users.robot
@@ -16,3 +16,8 @@ Scenario 02: Add a already registered user
     And add user again    
     Then check if user was not registered 
     
+Scenario 03: Find a user with id
+    Given add a new user
+    When add a created user in ServerRest    email=${EMAIL_TESTING}    expected_status_code=201
+    And query user data
+    Then check returned data

--- a/ApiTesting/resource_api_testing_users.robot
+++ b/ApiTesting/resource_api_testing_users.robot
@@ -23,6 +23,11 @@ add a created user in ServerRest
     ...        administrador=true
     create session in ServerRest
     ${response}    POST On Session    alias=add_user_session    url=/usuarios    json=${body}    expected_status=${expected_status_code}
+
+    IF  ${response.status_code} == 201
+        Set Test Variable    ${USER_ID}    ${response.json()["_id"]}
+    END
+    
     Set Test Variable    ${RESPONSE}    ${response.json()}
 
 check if user was registered with successfull
@@ -43,3 +48,15 @@ create session in ServerRest
     ...        accept=application/json
     ...        Content-Type=application/json
     Create Session    alias=add_user_session    url=${API_URL}    headers=${headers}
+
+query user data
+    ${response_query}    GET On Session    alias=add_user_session    url=/usuarios/${USER_ID}
+    Set Test Variable    ${RESP_QUERY}    ${response_query.json()}
+
+check returned data
+    Log    ${RESP_QUERY}
+    Dictionary Should Contain Item    ${RESP_QUERY}    nome             Fulano da Silva
+    Dictionary Should Contain Item    ${RESP_QUERY}    email            ${EMAIL_TESTING}
+    Dictionary Should Contain Item    ${RESP_QUERY}    password         teste
+    Dictionary Should Contain Item    ${RESP_QUERY}    administrador    true
+    Dictionary Should Contain Item    ${RESP_QUERY}    _id              ${USER_ID}


### PR DESCRIPTION
**Descrição**
Adicionar teste de API com método GET para buscar um usuário cadastrado através do id

**Setup**
- git clone git@github.com:Thiago-Viotto/Projeto-Pessoal-Robot-Framework.git
- Instalar o ChromeDriver da mesma versão do seu Chrome https://chromedriver.chromium.org/downloads
- No arquivo de resource, alterar a varíavel EXECUTABLE_PATH para o caminho do seu ChromeDriver
- Instalar o python https://www.python.org/downloads/

**Execução**
- robot APITesting/api_testing_users.robot

**Cenários**
Scenario 03: Find a user with id
Given add a new user
When add a created user in ServerRest email=${EMAIL_TESTING} expected_status_code=201
And query user data
Then check returned data